### PR TITLE
Maximize header paths on Mac

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -10,6 +10,7 @@ then
     export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+    export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
     export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
     export LINKFLAGS="${LDFLAGS}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 1.0.1
+  version: 1.0.2
 
 build:
   number: 0


### PR DESCRIPTION
This PR ( https://github.com/conda-forge/toolchain-feedstock/pull/3 ) should be merged first.

As it is not totally uncommon to run out of space in the header path when we are using `install_name_tool`, we should really just always be setting `-headerpad_max_install_names`. This makes that change.