### PR TITLE
Set the CMake deployment target OS on Mac

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -7,6 +7,7 @@ then
     export CXX=clang++
     export MACOSX_VERSION_MIN="10.7"
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -7,6 +7,7 @@ then
     unset CXX
     unset MACOSX_VERSION_MIN
     unset MACOSX_DEPLOYMENT_TARGET
+    unset CMAKE_OSX_DEPLOYMENT_TARGET
     unset CFLAGS
     unset CXXFLAGS
     unset LDFLAGS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 1.0.2
+  version: 1.1.0
 
 build:
   number: 0


### PR DESCRIPTION
This PR ( https://github.com/conda-forge/toolchain-feedstock/pull/4 ) should be merged first.

Sets the equivalent of `MACOSX_DEPLOYMENT_TARGET` except for CMake via `CMAKE_OSX_DEPLOYMENT_TARGET`. It's still set to 10.7 like everything else though.

cc @scopatz