### PR TITLE
Drop `-stdlib=libc++` from `LDFLAGS`

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -13,7 +13,7 @@ then
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
     export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export LDFLAGS="${LDFLAGS} -stdlib=libc++ -lc++"
+    export LDFLAGS="${LDFLAGS} -lc++"
     export LINKFLAGS="${LDFLAGS}"
 elif [ "$(uname)" == "Linux" ]
 then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 1.1.0
+  version: 1.1.1
 
 build:
   number: 0


### PR DESCRIPTION
Drop `-stdlib=libc++` from `LDFLAGS` as it seems to cause issues with `gfortran`. Besides `-lc++` should do the same thing and `-stdlib` is mainly used with the compiler. Please feel free to give feedback on this.