### PR TITLE
WIP: Use 10.9 as the minimum Mac OS

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -5,7 +5,7 @@ then
     # for Mac OSX
     export CC=clang
     export CXX=clang++
-    export MACOSX_VERSION_MIN="10.7"
+    export MACOSX_VERSION_MIN="10.9"
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 1.1.1
+  version: 2.0.0
 
 build:
   number: 0


### PR DESCRIPTION
Fixes https://github.com/conda-forge/toolchain-feedstock/issues/7

As most people seem in favor of this change, our binaries only support 10.9 anyways, and we are starting to encounter very challenging issues by not trying to set the minimum at 10.7, it only makes sense to bump this to 10.9.

This is not really WIP, but I would like to hear some feedback on this change.

cc @pelson @patricksnape @183amir @isuruf @ocefpaf @gillins @msarahan @mingwandroid