### PR TITLE
Drop `-lc++` flag

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -13,7 +13,7 @@ then
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
     export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export LDFLAGS="${LDFLAGS} -lc++"
+    export LDFLAGS="${LDFLAGS}"
     export LINKFLAGS="${LDFLAGS}"
 elif [ "$(uname)" == "Linux" ]
 then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.0.0
+  version: 2.0.1
 
 build:
   number: 0


### PR DESCRIPTION
This drops the `-lc++` flag from the `LDFLAGS`. I don't recall why we added it at the moment. I have yet to see this be helpful, but I have seen it cause issues. In some cases, one can end up linked to both `libstdc++` and `libc++` with this flag. In other cases, it can cause things that do not have any C++ code to be linked to `libc++`. As a result, I'm proposing that we drop it.
