### PR TITLE
specify absolute path of compiler envs

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -3,8 +3,8 @@
 if [ "$(uname)" == "Darwin" ]
 then
     # for Mac OSX
-    export CC=clang
-    export CXX=clang++
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
     export MACOSX_VERSION_MIN="10.9"
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
@@ -18,8 +18,8 @@ then
 elif [ "$(uname)" == "Linux" ]
 then
     # for Linux
-    export CC=gcc
-    export CXX=g++
+    export CC=/usr/bin/gcc
+    export CXX=/usr/bin/g++
     export CFLAGS="${CFLAGS}"
     # Boost wants to enable `float128` support on Linux by default.
     # However, we don't install `libquadmath` so it will fail to find


### PR DESCRIPTION
ensures that enabling toolchain specifies a specific compiler on the system, and not the one that may be installed in the env with the same name, unless explicitly requested.

This is the right thing to do for halide (https://github.com/conda-forge/staged-recipes/pull/2559#discussion_r105329430), but may not be what people want in general. When people install gcc as a build dep (and toolchain), do they expect the one in the env to be used by default without being explicitly selected? Should they?