### PR TITLE
Use a compiler wrapper

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -5,22 +5,20 @@ then
     # for Mac OSX
     export CC=clang
     export CXX=clang++
-    export MACOSX_VERSION_MIN="10.9"
-    export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
-    export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
-    export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
-    export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
-    export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export LDFLAGS="${LDFLAGS} -lc++"
-    export LINKFLAGS="${LDFLAGS}"
+    export CONDA_FORGE_MACOSX_VERSION_MIN="10.9"
+    export MACOSX_DEPLOYMENT_TARGET="${CONDA_FORGE_MACOSX_VERSION_MIN}"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="${CONDA_FORGE_MACOSX_VERSION_MIN}"
+    export CONDA_FORGE_CFLAGS="${CONDA_FORGE_CFLAGS} -mmacosx-version-min=${CONDA_FORGE_MACOSX_VERSION_MIN}"
+    export CONDA_FORGE_CXXFLAGS="${CONDA_FORGE_CXXFLAGS} -mmacosx-version-min=${CONDA_FORGE_MACOSX_VERSION_MIN}"
+    export CONDA_FORGE_CXXFLAGS="${CONDA_FORGE_CXXFLAGS} -stdlib=libc++"
+    export CONDA_FORGE_LDFLAGS="${CONDA_FORGE_LDFLAGS} -headerpad_max_install_names"
+    export CONDA_FORGE_LDFLAGS="${CONDA_FORGE_LDFLAGS} -mmacosx-version-min=${CONDA_FORGE_MACOSX_VERSION_MIN}"
+    export CONDA_FORGE_LDFLAGS="${CONDA_FORGE_LDFLAGS} -lc++"
 elif [ "$(uname)" == "Linux" ]
 then
     # for Linux
     export CC=gcc
     export CXX=g++
-    export CFLAGS="${CFLAGS}"
     # Boost wants to enable `float128` support on Linux by default.
     # However, we don't install `libquadmath` so it will fail to find
     # the needed headers and fail to compile things. Adding this flag
@@ -30,13 +28,24 @@ then
     #
     # https://svn.boost.org/trac/boost/ticket/9240
     #
-    export CXXFLAGS="${CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
-    export LDFLAGS="${LDFLAGS}"
-    export LINKFLAGS="${LDFLAGS}"
+    export CONDA_FORGE_CXXFLAGS="${CONDA_FORGE_CXXFLAGS} -DBOOST_MATH_DISABLE_FLOAT128"
 else
     echo "This system is unsupported by the toolchain."
     exit 1
 fi
 
-export CFLAGS="${CFLAGS} -m${ARCH}"
-export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
+# These are set by conda-build. Move them to CONDA_FORGE_* and unset
+export CONDA_FORGE_CFLAGS="${CONDA_FORGE_CFLAGS} ${CFLAGS}"
+export CONDA_FORGE_CXXFLAGS="${CONDA_FORGE_CXXFLAGS} ${CXXFLAGS}"
+export CONDA_FORGE_LDFLAGS="${CONDA_FORGE_LDFLAGS} ${LDFLAGS}"
+unset CFLAGS
+unset CXXFLAGS
+unset LDFLAGS
+
+export CONDA_FORGE_CFLAGS="${CONDA_FORGE_CFLAGS} -m${ARCH}"
+export CONDA_FORGE_CXXFLAGS="${CONDA_FORGE_CXXFLAGS} -m${ARCH}"
+export CONDA_FORGE_CPPFLAGS="${CONDA_FORGE_CPPFLAGS} -I${PREFIX}/include"
+export CONDA_FORGE_LDFLAGS="${CONDA_FORGE_LDFLAGS} -L${PREFIX}/lib"
+
+export _OLD_PATH=${PATH}
+export PATH="${PREFIX}/bin/conda_forge:${PATH}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,3 +7,12 @@ do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
     cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/toolchain_${CHANGE}.sh"
 done
+
+mkdir -p ${PREFIX}/bin/conda_forge
+cd ${PREFIX}/bin/conda_forge
+cp ${RECIPE_DIR}/conda-forge-cc cc
+
+for l in ftn f90 fc f95 f77 gfortran gcc g++ clang clang++ ld
+do
+  ln -s cc $l
+done

--- a/recipe/conda-forge-cc
+++ b/recipe/conda-forge-cc
@@ -1,0 +1,238 @@
+#!/bin/bash
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# Spack compiler wrapper script.
+#
+# Compiler commands go through this compiler wrapper in Spack builds.
+# The compiler wrapper is a thin layer around the standard compilers.
+# It enables several key pieces of functionality:
+#
+# 1. It allows Spack to swap compilers into and out of builds easily.
+# 2. It adds several options to the compile line so that spack
+#    packages can find their dependencies at build time and run time:
+#      -I           arguments for dependency /include directories.
+#      -L           arguments for dependency /lib directories.
+#      -Wl,-rpath   arguments for dependency /lib directories.
+#
+
+
+# die()
+# Prints a message and exits with error 1.
+function die {
+    echo "$@"
+    exit 1
+}
+
+# Figure out the type of compiler, the language, and the mode so that
+# the compiler script knows what to do.
+#
+# Possible languages are C, C++, Fortran
+# 'command' is set based on the input command to $CONDA_FORGE_[CC|CXX|FORT]
+#
+# 'mode' is set to one of:
+#    vcheck  version check
+#    cpp     preprocess
+#    cc      compile
+#    as      assemble
+#    ld      link
+#    ccld    compile & link
+
+command=$(basename "$0")
+case "$command" in
+    cpp)
+        mode=cpp
+        ;;
+    cc|c89|c99)
+        if [[ ! -z "$CC" ]]; then
+            command="$CC"
+        fi
+        lang_flags=C
+        ;;
+    c++)
+        if [[ ! -z "$CXX" ]]; then
+            command="$CXX"
+        fi
+        lang_flags=CXX
+        ;;
+    ftn|f90|fc|f95|f77)
+        if [[ ! -z "$FC" ]]; then
+            command="$FC"
+        fi
+        lang_flags=F
+        ;;
+    gcc|clang)
+        lang_flags=C
+        ;;
+    g++|clang++)
+        lang_flags=CXX
+        ;;
+    gfortran)
+        lang_flags=F
+        ;;
+    ld)
+        mode=ld
+        ;;
+    *)
+        die "Unkown compiler: $command"
+        ;;
+esac
+
+# If any of the arguments below are present, then the mode is vcheck.
+# In vcheck mode, nothing is added in terms of extra search paths or
+# libraries.
+if [[ -z $mode ]]; then
+    for arg in "$@"; do
+        if [[ $arg == -v || $arg == -V || $arg == --version || $arg == -dumpversion ]]; then
+            mode=vcheck
+            break
+        fi
+    done
+fi
+
+# Finish setting up the mode.
+if [[ -z $mode ]]; then
+    mode=ccld
+    for arg in "$@"; do
+        if [[ $arg == -E ]]; then
+            mode=cpp
+            break
+        elif [[ $arg == -S ]]; then
+            mode=as
+            break
+        elif [[ $arg == -c ]]; then
+            mode=cc
+            break
+        fi
+    done
+fi
+
+add_ccache=false
+if [[ -f $PREFIX/bin/ccache ]]; then
+    if [[ $mode == ccld || $mode == cc ]]; then
+        add_ccache=true
+    fi
+fi
+
+#
+# Filter '.' and Spack environment directories out of PATH so that
+# this script doesn't just call itself
+#
+IFS=':' read -ra env_path <<< "$PATH"
+IFS=':' read -ra conda_forge_env_dirs <<< "$PREFIX/bin/conda_forge"
+conda_forge_env_dirs+=("" ".")
+PATH=""
+for dir in "${env_path[@]}"; do
+    addpath=true
+    for env_dir in "${conda_forge_env_dirs[@]}"; do
+        if [[ $dir == $env_dir ]]; then
+            addpath=false
+            break
+        fi
+    done
+    if $addpath; then
+        PATH="${PATH:+$PATH:}$dir"
+    fi
+done
+export PATH
+
+if [[ $mode == vcheck ]]; then
+    exec ${command} "$@"
+fi
+
+# Darwin's linker has a -r argument that merges object files together.
+# It doesn't work with -rpath.
+# This variable controls whether they are added.
+add_rpaths=true
+if [[ ($mode == ld || $mode == ccld) && "$(uname)" == "Darwin" ]]; then
+    for arg in "$@"; do
+        if [[ ($arg == -r && $mode == ld) || ($arg == -Wl,-r && $mode == ccld) ]]; then
+            add_rpaths=false
+            break
+        fi
+    done
+fi
+
+# Save original command for debug logging
+input_command="$@"
+args=("$@")
+
+# Prepend cppflags, cflags, cxxflags, fcflags, fflags, and ldflags
+
+# Add ldflags
+case "$mode" in
+    ld|ccld)
+        args=(${CONDA_FORGE_LDFLAGS[@]} "${args[@]}") ;;
+esac
+
+# Add compiler flags.
+case "$mode" in
+    cc|ccld)
+    # Add c, cxx, fc, and f flags
+        case $lang_flags in
+            C)
+                args=(${CONDA_FORGE_CFLAGS[@]} "${args[@]}") ;;
+            CXX)
+                args=(${CONDA_FORGE_CXXFLAGS[@]} "${args[@]}") ;;
+        esac
+        ;;
+esac
+
+# Add cppflags
+case "$mode" in
+    cpp|as|cc|ccld)
+        args=(${CONDA_FORGE_CPPFLAGS[@]} "${args[@]}") ;;
+esac
+
+case "$mode" in
+    cc|ccld)
+        # Add fortran flags
+        case $lang_flags in
+            F)
+                args=(${CONDA_FORGE_FFLAGS[@]} "${args[@]}") ;;
+        esac
+        ;;
+esac
+
+if [[ "${CONDA_FORGE_ADD_RPATHS}" != "off" ]]; then
+    if [[ $mode == ccld ]]; then
+        $add_rpaths && args=("-Wl,-rpath,${PREFIX}/lib" "${args[@]}")
+    elif [[ $mode == ld ]]; then
+        $add_rpaths && args=("-rpath" "${PREFIX}/lib" "${args[@]}")
+    fi
+fi
+
+full_command=("$command" "${args[@]}")
+
+if [[ "${CONDA_FORGE_USE_CCACHE}" != "off" && $add_ccache == true ]]; then
+    full_command=("ccache" "$command" "${args[@]}")
+fi
+
+if [[ $CONDA_FORGE_DEBUG == "on" ]]; then
+    echo "[$mode-in ] $command $input_command"
+    echo "[$mode-out] ${full_command[@]}"
+fi
+
+exec "${full_command[@]}"

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -8,20 +8,22 @@ then
     unset MACOSX_VERSION_MIN
     unset MACOSX_DEPLOYMENT_TARGET
     unset CMAKE_OSX_DEPLOYMENT_TARGET
-    unset CFLAGS
-    unset CXXFLAGS
-    unset LDFLAGS
-    unset LINKFLAGS
+    unset CONDA_FORGE_CFLAGS
+    unset CONDA_FORGE_CPPFLAGS
+    unset CONDA_FORGE_CXXFLAGS
+    unset CONDA_FORGE_LDFLAGS
 elif [ "$(uname)" == "Linux" ]
 then
     # for Linux
     unset CC
     unset CXX
-    unset CFLAGS
-    unset CXXFLAGS
-    unset LDFLAGS
-    unset LINKFLAGS
+    unset CONDA_FORGE_CFLAGS
+    unset CONDA_FORGE_CPPFLAGS
+    unset CONDA_FORGE_CXXFLAGS
+    unset CONDA_FORGE_LDFLAGS
 else
     echo "This system is unsupported by our toolchain."
     exit 1
 fi
+
+export PATH="${_OLD_PATH}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.0.0
+  version: 3.0.0
 
 build:
   number: 0


### PR DESCRIPTION
This uses the compiler wrappers implemented in spack package manager and creates a new toolchain package. Link [here](https://github.com/LLNL/spack/blob/master/lib/spack/env/cc). Macports has a similar idea in their tracker, https://trac.macports.org/ticket/44413

There is a bash script `cc` installed in `$PREFIX/bin/conda_forge/` that looks at the arguments passed to it and process them before sending it to the real `cc` compiler. There are symlinks to `gcc, clang, g++, gfortran` etc.

This script looks at what mode the compiler/linker is invoked in and sets the mode. 'mode' is set to one of:
```
#    vcheck  version check
#    cpp     preprocess
#    cc      compile
#    as      assemble
#    ld      link
#    ccld    compile & link
```
1. `CONDA_FORGE_CFLAGS` is sent to the compiler if `cc` and `ccld`.
2. `CONDA_FORGE_CPPFLAGS` which includes `-I${PREFIX}/include` is sent in `cc, ccld, as, cpp`. 
3. `CONDA_FORGE_LDFLAGS` which includes `-L${PREFIX}/lib` is sent in `ld, ccld`.
4.  `rpath` is sent in `ccld` and `ld` modes with `-Wl,-rpath` and `-rpath`.

This avoids issues we've seen in toolchain package.

1. numpy.distutils packages like scipy.
Setting `LDFLAGS` env variable overwrites the `LDFLAGS` variable in numpy.distutils instead of appending. In toolchain3 we are not setting `LDFLAGS` at all, but sending them directly to the compiler and linker.

2. rpy2
rpy2's build system checks `CFLAGS` and preprocess them and chokes when `-headerpad_max_install_names` is set. toolchain3 does not have this problem.

This package also supports setting `CFLAGS` and `CXXFLAGS` which are sent to the compiler through the build system.

@conda-forge/toolchain, @conda-forge/core, what do you think?