### PR TITLE
Use PKG_NAME to copy activate/deactivate scripts

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,5 +4,5 @@ setlocal EnableDelayedExpansion
 :: This will allow them to be run on environment activation.
 FOR %%F IN (activate deactivate) DO (
     IF NOT EXIST %LIBRARY_PREFIX%\etc\conda\%%F.d MKDIR %LIBRARY_PREFIX%\etc\conda\%%F.d
-    COPY %RECIPE_DIR%/%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\toolchain_%%F.bat
+    COPY %RECIPE_DIR%/%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,5 +4,5 @@ setlocal EnableDelayedExpansion
 :: This will allow them to be run on environment activation.
 FOR %%F IN (activate deactivate) DO (
     IF NOT EXIST %LIBRARY_PREFIX%\etc\conda\%%F.d MKDIR %LIBRARY_PREFIX%\etc\conda\%%F.d
-    COPY %RECIPE_DIR%/%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    COPY %RECIPE_DIR%\%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
 )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,5 +5,5 @@
 for CHANGE in "activate" "deactivate"
 do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/toolchain_${CHANGE}.sh"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
 done


### PR DESCRIPTION
Should make it easier to copy and paste this code elsewhere without accidentally clobbering the `toolchain`'s activate/deactivate scripts.