### PR TITLE
Fix Windows [de]activate scripts' locations

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,8 @@
 setlocal EnableDelayedExpansion
 
-:: Copy the [de]activate scripts to %LIBRARY_PREFIX%\etc\conda\[de]activate.d.
+:: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
 :: This will allow them to be run on environment activation.
 FOR %%F IN (activate deactivate) DO (
-    IF NOT EXIST %LIBRARY_PREFIX%\etc\conda\%%F.d MKDIR %LIBRARY_PREFIX%\etc\conda\%%F.d
-    COPY %RECIPE_DIR%\%%F.bat %LIBRARY_PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    IF NOT EXIST %PREFIX%\etc\conda\%%F.d MKDIR %PREFIX%\etc\conda\%%F.d
+    COPY %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ test:
     # Verify the scripts are in-place.
     {% for state in ["activate", "deactivate"] %}
     - test -f "${PREFIX}/etc/conda/{{ state }}.d/toolchain_{{ state }}.sh"                        # [unix]
-    - if not exist %LIBRARY_PREFIX%\\etc\\conda\\{{ state }}.d\\toolchain_{{ state }}.bat exit 1  # [win]
+    - if not exist %PREFIX%\\etc\\conda\\{{ state }}.d\\toolchain_{{ state }}.bat exit 1  # [win]
     {% endfor %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.1.1
+  version: 2.1.2
 
 build:
   number: 0


### PR DESCRIPTION
Replaces PR ( https://github.com/conda-forge/toolchain-feedstock/pull/12 ).

The `activate.bat` and `deactivate.bat` scripts should be installed in `%PREFIX%` not `%LIBRARY_PREFIX%` on Windows. This relocates them. However, we didn't use them to do anything before or now; hence, the minor version bump instead of major.