### PR TITLE
libgfortran-ng version on mac

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ outputs:
       - gcc                                                          # [osx]
     run_exports:
       strong:
-        - libgfortran-ng >=4.9                                       # [unix]
+        - libgfortran-ng >=4.9                                       # [linux]
+        - libgfortran-ng >=3.0                                       # [osx]
 {% endif %}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.1.2
+  version: 2.1.3
 
 build:
   number: 0


### PR DESCRIPTION
Should fix `{{ compiler('fortran') }}` not working on Mac: https://github.com/conda-forge/staged-recipes/pull/5622#issuecomment-387181939.