### PR TITLE
set PKG_CONFIG_PATH to search both host and build envs

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -46,3 +46,9 @@ export CFLAGS="${CFLAGS} -m${ARCH}"
 export CXXFLAGS="${CXXFLAGS} -m${ARCH}"
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
+if [[ ! -z "${BUILD_PREFIX}" && "${BUILD_PREFIX}" != "${PREFIX}" ]]
+then
+    export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${BUILD_PREFIX}/lib/pkgconfig"
+fi
+env | sort

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -25,3 +25,5 @@ else
     echo "This system is unsupported by our toolchain."
     exit 1
 fi
+
+unset PKG_CONFIG_PATH


### PR DESCRIPTION
ensures pkg-config in the build env will find packages in the host env and vice versa

pkg-config counterpart to #31

might be enough to resolve https://github.com/conda-forge/conda-smithy/issues/821 since it seems like maybe cmake doesn't need any help.