### PR TITLE
toolchain_fort requires libgfortran

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.1.5
+  version: 2.1.6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,7 @@ outputs:
       - gcc                                                          # [osx]
     run_exports:
       strong:
-        - libgfortran-ng >=4.9                                       # [linux]
-        - libgfortran-ng >=3.0                                       # [osx]
+        - libgfortran >=3.0  # [unix]
 {% else %}
   - name: m2w64-toolchain_{{ target_platform }}
     requirements:


### PR DESCRIPTION
it doesn't appear to be fully compatible with libgfortran-ng

builds linking libgfortran-ng are failing with:

    Internal Error: get_unit(): Bad internal unit KIND

Discovered in hdf5 cb3 updates: https://github.com/conda-forge/hdf5-feedstock/pull/88

To reproduce and verify:

checkout hdf5-feedstock@d165fe0

1. Start linux build `CONFIG=linux_ bash .circleci/run_docker_build.sh` (it will fail in the fortran stage, after a pretty long time)
2.  `docker run --rm -it -v $PWD:/home/conda/feedstock_root condaforge/linux-anvil bash` to get a session in the build image with the failed build dir
3. `cd /home/conda/feedstock_root/build_artifacts/hdf5_<stamp>/work/fortran` cd to the fortran src dir
4.  load relevant env (or all of it) from conda_build.sh
5. `make clean && make` will fail with `Internal Error: get_unit(): Bad internal unit KIND`
6. trade libgfortran-ng for libgfortran `conda remove -yq libgfortran-ng && conda install -yq libgfortran`
7. `make clean && make` will succeed now that `libgfortran-ng` has been replaced with `libgfortran`.

I'm sure there's a simpler example, but I don't know enough fortran to cook it up.

It's possible that this is only a build-time problem, i.e. that libgfortran-ng 7 needs to not be in the host env while libs like hdf5 are built, but it will work fine when the compiled programs *run* in the end. I don't know if that's true, and I also don't know how to achieve that - different run_exports applied to the host env during build and the 'actual' run env.