### PR TITLE
add -isysroot CONDA_BUILD_SYSROOT to cflags/cxxflags

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -15,6 +15,10 @@ then
     export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+    if [ ! -z "$CONDA_BUILD_SYSROOT" ]; then
+        export CFLAGS="${CFLAGS} -isysroot ${CONDA_BUILD_SYSROOT}"
+        export CXXFLAGS="${CXXFLAGS} -isysroot ${CONDA_BUILD_SYSROOT}"
+    fi
     export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
     export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export LDFLAGS="${LDFLAGS} -lc++"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.2.0
+  version: 2.2.1
 
 build:
   number: 0


### PR DESCRIPTION
The conda compilers ship patches to handle CONDA_BUILD_SYSROOT directly, but toolchain compilers don't.

This is needed for toolchain builds to be compatible with older macOS, not just MACOSX_DEPLOYMENT_TARGET, which can be insufficient.

Apparently some build tools (cmake and friends) can strip sysroot from CFLAGS, so recipes may still need to take care to ensure this is applied.

For an example, see [this failed build](https://travis-ci.org/conda-forge/parmetis-feedstock/jobs/428047190#L945) which used openmpi after [switching to circleci builds](https://github.com/conda-forge/openmpi-feedstock/commit/52de5ed665668ac74a9c898215798d74ab9125c5) (latest openmpi can no longer be built with the old clang in xcode 6). After [explicitly setting sysroot](https://github.com/conda-forge/openmpi-feedstock/pull/29) in the openmpi recipe and rebuilding, the same parmetis recipe [succeeded](https://travis-ci.org/conda-forge/parmetis-feedstock/jobs/439090445). Notably, the non-toolchain builds succeeded without the fix, because they handled CONDA_BUILD_SYSROOT already.

The error in this case is a very common symptom of when the minimum OS isn't properly targeted:

```
dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
  Referenced from: $PREFIX/lib/libwhatever.dylib
  Expected in: flat namespace
```

`_clock_gettime` is new in 10.12 and not present in 10.10, which is the OS of the xcode6.4 image.


So this is a good test case for updating the mac build image, which must be done soon as Travis is going to stop supporting Xcode 6.4 images in January.

- MACOSX_DEPLOYMENT_TARGET is *not enough* when using an SDK >= the target os version
- Need 10.9 SDK on the system (as is done on circleci)
- Must set CONDA_BUILD_SYSROOT to the 10.9 SDK prefix in all cases
- Must set `-isysroot $CONDA_BUILD_SYSROOT` unless using new conda compilers, which handle CONDA_BUILD_SYSROOT themselves
- Building with 10.9 SDK *and* MACOSX_DEPLOYMENT_TARGET=10.9 does work with a build system newer than the target,
  so we shouldn't be stuck on ancient Xcode images as long as we set both of these appropriately.
