### PR TITLE
Set SDKROOT environment variable on macOS for CMake

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -16,6 +16,8 @@ then
     export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
     export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
     if [ ! -z "$CONDA_BUILD_SYSROOT" ]; then
+        export CMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}"
+        export SDKROOT="${CONDA_BUILD_SYSROOT}"
         export CFLAGS="${CFLAGS} -isysroot ${CONDA_BUILD_SYSROOT}"
         export CXXFLAGS="${CXXFLAGS} -isysroot ${CONDA_BUILD_SYSROOT}"
     fi

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -12,6 +12,8 @@ then
     unset MACOSX_VERSION_MIN
     unset MACOSX_DEPLOYMENT_TARGET
     unset CMAKE_OSX_DEPLOYMENT_TARGET
+    unset CMAKE_OSX_SYSROOT
+    unset SDKROOT
     unset CFLAGS
     unset CXXFLAGS
     unset LDFLAGS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.2.2
+  version: 2.3.0
 
 build:
   number: 0


### PR DESCRIPTION
Follow-on to PR ( https://github.com/conda-forge/toolchain-feedstock/pull/46 ) to improve CMake handling and usage of the desired macOS SDK.

Sets the `SDKROOT` environment variable, which [CMake uses to set `CMAKE_OSX_SYSROOT`]( https://cmake.org/cmake/help/v3.12/variable/CMAKE_OSX_SYSROOT.html ). This is in turn used to add `-isysroot` with the preferred macOS SDK to the compiler flags as we also do here manually for non-CMake builds (thanks to the aforementioned PR). This ensures that if CMake strips out our manual addition of `-isysroot` from the compiler flags, that it will add its own `-isysroot` flag to the compiler flags as well.

---

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

cc @minrk