### PR TITLE
Set environment variables for common build tools

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -43,6 +43,8 @@ then
     export F95=$FC
     export LD=ld
     export NM=nm
+    export OBJCOPY=objcopy
+    export OBJDUMP=objdump
     export RANLIB=ranlib
     export STRIP=strip
     export CFLAGS="${CFLAGS}"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -3,12 +3,17 @@
 if [ "$(uname)" == "Darwin" ]
 then
     # for Mac OSX
+    export AR=ar
     export CC=clang
     export CXX=clang++
     export FC=gfortran
     export F77=$FC
     export F90=$FC
     export F95=$FC
+    export LD=ld
+    export NM=nm
+    export RANLIB=ranlib
+    export STRIP=strip
     export MACOSX_VERSION_MIN="10.9"
     export MACOSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
     export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
@@ -29,12 +34,17 @@ then
 elif [ "$(uname)" == "Linux" ]
 then
     # for Linux
+    export AR=ar
     export CC=gcc
     export CXX=g++
     export FC=gfortran
     export F77=$FC
     export F90=$FC
     export F95=$FC
+    export LD=ld
+    export NM=nm
+    export RANLIB=ranlib
+    export STRIP=strip
     export CFLAGS="${CFLAGS}"
     # Boost wants to enable `float128` support on Linux by default.
     # However, we don't install `libquadmath` so it will fail to find

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -3,12 +3,17 @@
 if [ "$(uname)" == "Darwin" ];
 then
     # for Mac OSX
+    unset AR
     unset CC
     unset CXX
     unset FC
     unset F77
     unset F90
     unset F95
+    unset LD
+    unset NM
+    unset RANLIB
+    unset STRIP
     unset MACOSX_VERSION_MIN
     unset MACOSX_DEPLOYMENT_TARGET
     unset CMAKE_OSX_DEPLOYMENT_TARGET
@@ -21,12 +26,17 @@ then
 elif [ "$(uname)" == "Linux" ]
 then
     # for Linux
+    unset AR
     unset CC
     unset CXX
     unset FC
     unset F77
     unset F90
     unset F95
+    unset LD
+    unset NM
+    unset RANLIB
+    unset STRIP
     unset CFLAGS
     unset CXXFLAGS
     unset LDFLAGS

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -35,6 +35,8 @@ then
     unset F95
     unset LD
     unset NM
+    unset OBJCOPY
+    unset OBJDUMP
     unset RANLIB
     unset STRIP
     unset CFLAGS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toolchain
-  version: 2.3.0
+  version: 2.4.0
 
 build:
   number: 0


### PR DESCRIPTION
Includes a few other environment variables for other command line tools. Should aid in the migration to the new toolchain, which sets these as well.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
